### PR TITLE
Add shortlist of favorite colorschemes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An add-on for [vim-colorscheme-switcher](http://github.com/xolox/vim-colorscheme
 
 * Convenience functions for managing the colorscheme blacklist.
 * Automatically load last used colorscheme upon starting vim or (optionally) loading a session.
-* Store last used colorscheme and blacklist on file.
+* Manage a shortlist of favorite colorschemes, including the ability to switch to a random colorscheme from the shortlist.
+* Store last used colorscheme, blacklist, and shortlist on file.
 
 ## Author
 [Taverius](http://github.com/Taverius)
@@ -58,13 +59,37 @@ Optionally, takes a colorscheme name as an argument, and operates on that instea
 
 ### The `:BlacklistPruneColorScheme` command
 
-Removes non-existent (i.e. not in runtime path) colorschemes from blacklist.
+Remove non-existent (i.e. not in runtime path) colorschemes from the blacklist.
+
+### The `:ShortlistAddColorScheme` command
+
+Add the current colorscheme to the shortlist.
+
+Optionally, takes a colorscheme name as an argument, and operates on that instead of the current one.
+
+### The `:ShortlistRemColorScheme` command
+
+Remove the current colorscheme from the shortlist.
+
+Optionally, takes a colorscheme name as an argument, and operates on that instead of the current one.
+
+### The `:ShortlistPruneColorScheme` command
+
+Remove non-existent (i.e. not in runtime path) colorschemes from the shortlist.
+
+### The `:ShortlistRandomColorScheme` command
+
+Switch to a random colorscheme from the shortlist.
 
 ### The `:SwitchToColorScheme` command
 
 Syntactic sugar for `xolox#colorscheme_switcher#switch_to(colorscheme)`, takes a colorscheme name as argument.
 
 Useful for switching to a colorscheme you just installed with Vundle/NeoBundle/etc, or to use as custom command for a colorscheme browser - for example, [unite.vim](http://github.com/Shougo/unite.vim) with [unite-colorscheme](http://github.com/ujihisa/unite-colorscheme)
+
+### The `:FreshColorScheme` command
+
+Similar to `:RandomColorScheme` (from [vim-colorscheme-switcher](http://github.com/xolox/vim-colorscheme-switcher)), but switch to a random colorscheme that is neither in the blacklist nor in the shortlist.
 
 ## Options
 

--- a/doc/colorscheme-manager.txt
+++ b/doc/colorscheme-manager.txt
@@ -11,7 +11,12 @@ Contents ~
   1. The |:BlacklistAddColorScheme| command
   2. The |:BlacklistRemColorScheme| command
   3. The |:BlacklistPruneColorScheme| command
-  4. The |:SwitchToColorScheme| command
+  4. The |:ShortlistAddColorScheme| command
+  5. The |:ShortlistRemColorScheme| command
+  6. The |:ShortlistPruneColorScheme| command
+  7. The |:ShortlistRandomColorScheme| command
+  8. The |:SwitchToColorScheme| command
+  9. The |:FreshColorScheme| command
  3. Options                                      |colorscheme-manager-options|
   1. The |g:colorscheme_manager_define_mappings| option
   2. The |g:colorscheme_manager_blacklist_direction| option
@@ -28,7 +33,10 @@ An add-on for vim-colorscheme-switcher [2].
 - Convenience functions for managing the colorscheme blacklist.
 - Automatically load last used colorscheme upon starting vim or
   (optionally) loading a session.
-- Store last used colorscheme and blacklist on file, using tlib [3].
+- Manage a shortlist of favorite colorschemes, including the ability to switch
+  to a random colorscheme from the shortlist
+- Store last used colorscheme, blacklist, and shortlist on file, using tlib
+  [3].
 
 _Please note that the vim-colorscheme-manager plug-in requires the
 vim-colorscheme-switcher [2] and vim-misc [3] plug-ins which must be installed
@@ -58,7 +66,35 @@ instead of the current one.
 -------------------------------------------------------------------------------
 The *:BlacklistPruneColorScheme* command
 
-Removes non-existent (i.e. not in runtime path) colorschemes from blacklist.
+Remove non-existent (i.e. not in runtime path) colorschemes from the
+blacklist.
+
+-------------------------------------------------------------------------------
+The *:ShortlistAddColorScheme* command
+
+Add the current colorscheme to the shortlist.
+
+Optionally, takes a colorscheme name as an argument, and operates on that
+instead of the current one.
+
+-------------------------------------------------------------------------------
+The *:ShortlistRemColorScheme* command
+
+Remove the current colorscheme from the shortlist.
+
+Optionally, takes a colorscheme name as an argument, and operates on that
+instead of the current one.
+
+-------------------------------------------------------------------------------
+The *:ShortlistPruneColorScheme* command
+
+Remove non-existent (i.e. not in runtime path) colorschemes from the
+shortlist.
+
+-------------------------------------------------------------------------------
+The *:ShortlistRandomColorScheme* command
+
+Switch to a random colorscheme from the shortlist.
 
 -------------------------------------------------------------------------------
 The *:SwitchToColorScheme* command
@@ -68,7 +104,13 @@ colorscheme name as argument.
 
 Useful for switching to a colorscheme you just installed with a plugin
 manager, or to use as custom command for a colorscheme browser - for example,
-unite.vim [4] with unite-colorscheme [5]
+unite.vim [4] with unite-colorscheme [5].
+
+-------------------------------------------------------------------------------
+The *:FreshColorScheme* command
+
+Similar to |:RandomColorScheme|, but switch to a random colorscheme that is
+neither in the blacklist nor in the shortlist.
 
 ===============================================================================
                                                  *colorscheme-manager-options*

--- a/plugin/colorscheme-manager.vim
+++ b/plugin/colorscheme-manager.vim
@@ -56,8 +56,15 @@ command! -bar -nargs=? -complete=color
 command! -bar -nargs=? -complete=color
             \ BlacklistRemColorScheme call colorscheme_manager#rem_blacklist(<f-args>)
 command! BlacklistPruneColorScheme call colorscheme_manager#prune_blacklist()
+command! -bar -nargs=? -complete=color
+            \ ShortlistAddColorScheme call colorscheme_manager#add_shortlist(<f-args>)
+command! -bar -nargs=? -complete=color
+            \ ShortlistRemColorScheme call colorscheme_manager#rem_shortlist(<f-args>)
+command! ShortlistPruneColorScheme call colorscheme_manager#prune_shortlist()
+command! ShortlistRandomColorScheme call xolox#colorscheme_switcher#random_among(g:colorscheme_manager_shortlist)
 command! -nargs=1 -complete=color
             \ SwitchToColorScheme call xolox#colorscheme_switcher#switch_to(<f-args>)
+command! FreshColorScheme call colorscheme_manager#fresh_colorscheme()
 
 
 


### PR DESCRIPTION
**THIS PR IS NOT READY**

I like variety and I like switching up my colorscheme to try something new. But sometimes I would prefer *some*, but not *all* of the variety and randomly pick from a list of my favourite colorschemes. This PR enables just that:

- management of the shortlist is very similar to the blacklist with `:ShortlistAddColorScheme`, `:ShortlistRemColorScheme`, `:ShortlistPruneColorScheme`
- `:ShortlistRandomColorScheme` command for a little bit but not too much of variety
- `:FreshColorScheme` command similar to `:RandomColorScheme`, but that picks a fresh colorscheme i.e. one neither in the blacklist nor in the shortlist
- the shortlist is of course persisent
- docs & README.md changes

I opened https://github.com/xolox/vim-colorscheme-switcher/pull/12 in order to implement some needed functionality. This PR will **not** work unless used against these changes.